### PR TITLE
Remove support for old version names

### DIFF
--- a/make-deploy-notes/uploadChangelog.php
+++ b/make-deploy-notes/uploadChangelog.php
@@ -77,17 +77,8 @@ function getPreviousVersion( $input ) {
 	} else {
 		$minor--;
 	}
-	// wmf branches in the 1.26 release cycle and prior has another version
-	// notation
-	// FIXME: This is useful for the time we change to semver and can
-	// (probably) be removed after
-	// four or five wmf-versions, or after REL1_27 was released.
-	if ( $major <= 26 ) {
-		return "wmf/1.{$major}wmf{$minor}";
-	} else {
-		// anything else (higher and equal 1.27) uses new semver notation
-		return "wmf/1.{$major}.0-wmf.{$minor}";
-	}
+
+	return "wmf/1.{$major}.0-wmf.{$minor}";
 }
 
 /**


### PR DESCRIPTION
See the comment removed, we're fare ahead of REL1_27.